### PR TITLE
feat: add fill-multiple-blanks/cloze matching exercise type

### DIFF
--- a/vue/src/Cloze/components/ClozeMatching.vue
+++ b/vue/src/Cloze/components/ClozeMatching.vue
@@ -17,7 +17,11 @@
                 style="position: relative"
               >
                 <!-- {{ word.revealed ? word.word : blankFillers(word.word.length) }} -->
-                {{ word.revealed ? word.word : blankFillers(word.word.length) }}
+                {{
+                  !word.blank || word.revealed
+                    ? word.word
+                    : blankFillers(word.word.length)
+                }}
                 <RippleAnimation
                   :playing="word.audio ? word.audio.playing : false"
                   :scale="1"

--- a/vue/src/Cloze/data/ClozeMatchingTestData.ts
+++ b/vue/src/Cloze/data/ClozeMatchingTestData.ts
@@ -54,7 +54,7 @@ export default function ClozeMatchingTestData(): ClozeMatchingExercise {
         audio: ExerciseProvider.createAudio(术),
       },
       {
-        word: '兄弟＿姐妹',
+        word: '兄弟姐妹',
         isBlank: true,
         revealed: false,
         audio: ExerciseProvider.createAudio(术),


### PR DESCRIPTION
- closes #50 马丽 practices fill-multiple-blanks/cloze matching
- closes #39 马丽 completes a strict audio-word pair matching exercise

**Features**
- Adds optionality to audio when matching so that strict audio-word
  matches can be facilitated by a lesson definiton without audio for words
  and a plain audio symbol for the audio parts.

**Refactoring**

**Other**