### PR TITLE
refactor: rename from 种字立爱 to 立爱种字

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Seedling](https://github.com/nodepa/seedling/blob/master/asset-sources/seedling-banner.png)
 A mobile-first literacy webapp for adults
 
-Available as 种字立爱 - Seedling for Putonghua Simplified Chinese, at [种字.com](https://种字.com)
+Available as 立爱种字 - Seedling for Putonghua Simplified Chinese, at [种字.com](https://种字.com)
 
 ## Development
 

--- a/vue/README.md
+++ b/vue/README.md
@@ -1,4 +1,4 @@
-# 种字立爱 - Seedling for Putonghua Simplified Chinese, at [种字.com](https://种字.com)
+# 立爱种字 - Seedling for Putonghua Simplified Chinese, at [种字.com](https://种字.com)
 
 ## Project setup
 ```

--- a/vue/src/App.vue
+++ b/vue/src/App.vue
@@ -3,7 +3,7 @@
     <v-app-bar app flat color="background">
       <div class="d-flex align-center">
         <v-img
-          alt="种字立爱 Logo"
+          alt="立爱种字 Logo"
           class="shrink mr-2"
           contain
           transition="scale-transition"
@@ -18,7 +18,7 @@
           min-width="100"
           width="100"
         >
-          种字立爱
+          立爱种字
         </span>
         <span class="caption white--text" if="branch && jobId"
           >({{ branch }}/{{ jobId }})

--- a/vue/src/views/About.vue
+++ b/vue/src/views/About.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="about">
-    <h1>种字立爱</h1>
+    <h1>立爱种字</h1>
     <Logo />
     <p class="px-14">
-      种字立爱 is a literacy education tool developed on behalf of
+      立爱种字 is a literacy education tool developed on behalf of
       <a href="https://liaieducation.com">Li Ai Education</a> as part of a
       research project aiming to empower rural citizens.
     </p>

--- a/vue/vue.config.js
+++ b/vue/vue.config.js
@@ -1,4 +1,4 @@
-const name = '种字立爱';
+const name = '立爱种字';
 module.exports = {
   devServer: {
     compress: true,


### PR DESCRIPTION
Discussions with Li Ai Education revealed that a more proper order of 立爱 and 种字 is 立爱种字. All references to 种字立爱 should therefore be changed to 立爱种字.