### PR TITLE
fix: rename banner link from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Seedling](https://github.com/nodepa/seedling/blob/master/asset-sources/seedling-banner.png)
+![Seedling](https://github.com/nodepa/seedling/blob/main/asset-sources/seedling-banner.png)
 A mobile-first literacy webapp for adults
 
 Available as 立爱种字 - Seedling for Putonghua Simplified Chinese, at [种字.com](https://种字.com)


### PR DESCRIPTION
When the `main` branch was renamed from `master`, I forgot to update the link in the README that pointed to `master`. This fix has it point to the `main` branch instead.