### PR TITLE
infra: Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/vue"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "UTC"
+    reviewers:
+      - "toshify"
+    commit-message:
+      prefix: "infra:"
+


### PR DESCRIPTION
Because:
- keeping dependencies up to date keeps end users safer
- continuous integration limits the potential negative impact
this commit will:
- configure dependabot to prepare dependency updates weekly