### PR TITLE
refactor: Improve readability and typing

### DIFF
--- a/app/src/BottomNavigationBar/components/InstructionsButton.vue
+++ b/app/src/BottomNavigationBar/components/InstructionsButton.vue
@@ -59,7 +59,7 @@ export default class InstructionsButton extends Vue {
 
       // Add <audio> element to Instruction.Collection to provoke cancelling whenever another instruction starts playing
       const audioEl = this.$refs.instructionsButtonAudio as HTMLAudioElement;
-      Instruction.Collection.push(audioEl);
+      Instruction.AudioCollection.push(audioEl);
       audioEl.currentTime = 0;
       audioEl.play();
     }

--- a/app/src/common/directives/InstructionDirective.test.ts
+++ b/app/src/common/directives/InstructionDirective.test.ts
@@ -72,7 +72,7 @@ describe('class Instruction', () => {
   });
 
   it('constructor: instance added to instruction collection', () => {
-    expect(Instruction.Collection.length).toBe(1);
+    expect(Instruction.AudioCollection.length).toBe(1);
   });
 
   it('addEventListener: adds event listeners', () => {
@@ -217,12 +217,12 @@ describe('class Instruction', () => {
     const el = Object.values(vm.$el.children).find((elm) => {
       return elm.tagName === 'AUDIO';
     }) as HTMLAudioElement;
-    const count = Instruction.Collection.length;
-    expect(Instruction.Collection.includes(el)).toBe(true);
+    const count = Instruction.AudioCollection.length;
+    expect(Instruction.AudioCollection.includes(el)).toBe(true);
 
     instruction.delist();
 
-    expect(Instruction.Collection.length).toBe(count - 1);
-    expect(Instruction.Collection.includes(el)).toBe(false);
+    expect(Instruction.AudioCollection.length).toBe(count - 1);
+    expect(Instruction.AudioCollection.includes(el)).toBe(false);
   });
 });

--- a/app/src/common/directives/InstructionDirective.ts
+++ b/app/src/common/directives/InstructionDirective.ts
@@ -28,7 +28,7 @@ export interface InstructionsOptions {
 }
 
 export class Instruction {
-  public static Collection: Array<HTMLAudioElement> = [];
+  public static AudioCollection: Array<HTMLAudioElement> = [];
 
   private hostElement: InstructionElement;
 
@@ -82,7 +82,7 @@ export class Instruction {
     this.audioElement.src = audioUrl;
     this.addAudioListeners();
     this.hostElement.appendChild(this.audioElement);
-    Instruction.Collection.push(this.audioElement);
+    Instruction.AudioCollection.push(this.audioElement);
   } // end constructor
 
   public setAudioSrc(audioUrl: string): void {
@@ -146,8 +146,8 @@ export class Instruction {
   }
 
   public delist(): void {
-    Instruction.Collection.splice(
-      Instruction.Collection.indexOf(this.audioElement),
+    Instruction.AudioCollection.splice(
+      Instruction.AudioCollection.indexOf(this.audioElement),
       1,
     );
   }
@@ -158,7 +158,7 @@ export class Instruction {
         this.animation1.$props.playing = true;
         this.animation2.$props.playing = true;
       }
-      Instruction.Collection.forEach((audioElement) => {
+      Instruction.AudioCollection.forEach((audioElement) => {
         if (audioElement !== this.audioElement && !audioElement.paused) {
           audioElement.pause();
         }

--- a/app/src/common/directives/__snapshots__/InstructionDirective.test.ts.snap
+++ b/app/src/common/directives/__snapshots__/InstructionDirective.test.ts.snap
@@ -1132,7 +1132,7 @@ Instruction {
   "badge": Badge {
     "$attrs": Object {},
     "$children": Array [
-      VueComponent {
+      InstructionsIcon {
         "$attrs": Object {},
         "$children": Array [],
         "$createElement": [Function],
@@ -1202,7 +1202,7 @@ Instruction {
             "ns": undefined,
             "parent": undefined,
             "raw": false,
-            "tag": "vue-component-409-InstructionsIcon",
+            "tag": "vue-component-407-InstructionsIcon",
             "text": undefined,
           },
           "_renderChildren": undefined,
@@ -1263,7 +1263,7 @@ Instruction {
           "ns": undefined,
           "parent": undefined,
           "raw": false,
-          "tag": "vue-component-409-InstructionsIcon",
+          "tag": "vue-component-407-InstructionsIcon",
           "text": undefined,
         },
         "$vuetify": [Circular],
@@ -1277,7 +1277,7 @@ Instruction {
         "_isDestroyed": false,
         "_isMounted": true,
         "_isVue": true,
-        "_renderProxy": VueComponent {
+        "_renderProxy": InstructionsIcon {
           "$attrs": Object {},
           "$children": Array [],
           "$createElement": [Function],
@@ -1347,7 +1347,7 @@ Instruction {
               "ns": undefined,
               "parent": undefined,
               "raw": false,
-              "tag": "vue-component-409-InstructionsIcon",
+              "tag": "vue-component-407-InstructionsIcon",
               "text": undefined,
             },
             "_renderChildren": undefined,
@@ -1408,7 +1408,7 @@ Instruction {
             "ns": undefined,
             "parent": undefined,
             "raw": false,
-            "tag": "vue-component-409-InstructionsIcon",
+            "tag": "vue-component-407-InstructionsIcon",
             "text": undefined,
           },
           "$vuetify": [Circular],
@@ -1550,7 +1550,7 @@ Instruction {
               "ns": undefined,
               "parent": undefined,
               "raw": false,
-              "tag": "vue-component-409-InstructionsIcon",
+              "tag": "vue-component-407-InstructionsIcon",
               "text": undefined,
             },
             "raw": false,
@@ -1729,7 +1729,7 @@ Instruction {
             "ns": undefined,
             "parent": undefined,
             "raw": false,
-            "tag": "vue-component-409-InstructionsIcon",
+            "tag": "vue-component-407-InstructionsIcon",
             "text": undefined,
           },
           "raw": false,
@@ -1861,7 +1861,7 @@ Instruction {
     "_renderProxy": Badge {
       "$attrs": Object {},
       "$children": Array [
-        VueComponent {
+        InstructionsIcon {
           "$attrs": Object {},
           "$children": Array [],
           "$createElement": [Function],
@@ -1931,7 +1931,7 @@ Instruction {
               "ns": undefined,
               "parent": undefined,
               "raw": false,
-              "tag": "vue-component-409-InstructionsIcon",
+              "tag": "vue-component-407-InstructionsIcon",
               "text": undefined,
             },
             "_renderChildren": undefined,
@@ -1992,7 +1992,7 @@ Instruction {
             "ns": undefined,
             "parent": undefined,
             "raw": false,
-            "tag": "vue-component-409-InstructionsIcon",
+            "tag": "vue-component-407-InstructionsIcon",
             "text": undefined,
           },
           "$vuetify": [Circular],
@@ -2006,7 +2006,7 @@ Instruction {
           "_isDestroyed": false,
           "_isMounted": true,
           "_isVue": true,
-          "_renderProxy": VueComponent {
+          "_renderProxy": InstructionsIcon {
             "$attrs": Object {},
             "$children": Array [],
             "$createElement": [Function],
@@ -2076,7 +2076,7 @@ Instruction {
                 "ns": undefined,
                 "parent": undefined,
                 "raw": false,
-                "tag": "vue-component-409-InstructionsIcon",
+                "tag": "vue-component-407-InstructionsIcon",
                 "text": undefined,
               },
               "_renderChildren": undefined,
@@ -2137,7 +2137,7 @@ Instruction {
               "ns": undefined,
               "parent": undefined,
               "raw": false,
-              "tag": "vue-component-409-InstructionsIcon",
+              "tag": "vue-component-407-InstructionsIcon",
               "text": undefined,
             },
             "$vuetify": [Circular],
@@ -2279,7 +2279,7 @@ Instruction {
                 "ns": undefined,
                 "parent": undefined,
                 "raw": false,
-                "tag": "vue-component-409-InstructionsIcon",
+                "tag": "vue-component-407-InstructionsIcon",
                 "text": undefined,
               },
               "raw": false,
@@ -2458,7 +2458,7 @@ Instruction {
               "ns": undefined,
               "parent": undefined,
               "raw": false,
-              "tag": "vue-component-409-InstructionsIcon",
+              "tag": "vue-component-407-InstructionsIcon",
               "text": undefined,
             },
             "raw": false,
@@ -2603,7 +2603,7 @@ Instruction {
                 "asyncFactory": undefined,
                 "asyncMeta": undefined,
                 "children": undefined,
-                "componentInstance": VueComponent {
+                "componentInstance": InstructionsIcon {
                   "$attrs": Object {},
                   "$children": Array [],
                   "$createElement": [Function],
@@ -2646,7 +2646,7 @@ Instruction {
                   "_isDestroyed": false,
                   "_isMounted": true,
                   "_isVue": true,
-                  "_renderProxy": VueComponent {
+                  "_renderProxy": InstructionsIcon {
                     "$attrs": Object {},
                     "$children": Array [],
                     "$createElement": [Function],
@@ -2990,7 +2990,7 @@ Instruction {
                 "ns": undefined,
                 "parent": undefined,
                 "raw": false,
-                "tag": "vue-component-409-InstructionsIcon",
+                "tag": "vue-component-407-InstructionsIcon",
                 "text": undefined,
               },
             ],
@@ -3145,7 +3145,7 @@ Instruction {
               "asyncFactory": undefined,
               "asyncMeta": undefined,
               "children": undefined,
-              "componentInstance": VueComponent {
+              "componentInstance": InstructionsIcon {
                 "$attrs": Object {},
                 "$children": Array [],
                 "$createElement": [Function],
@@ -3188,7 +3188,7 @@ Instruction {
                 "_isDestroyed": false,
                 "_isMounted": true,
                 "_isVue": true,
-                "_renderProxy": VueComponent {
+                "_renderProxy": InstructionsIcon {
                   "$attrs": Object {},
                   "$children": Array [],
                   "$createElement": [Function],
@@ -3532,7 +3532,7 @@ Instruction {
               "ns": undefined,
               "parent": undefined,
               "raw": false,
-              "tag": "vue-component-409-InstructionsIcon",
+              "tag": "vue-component-407-InstructionsIcon",
               "text": undefined,
             },
           ],

--- a/app/src/common/icons/InstructionsIcon.vue
+++ b/app/src/common/icons/InstructionsIcon.vue
@@ -15,7 +15,10 @@
 </template>
 
 <script lang="ts">
-export default { name: 'InstructionsIcon' };
+import { Component, Vue } from 'vue-property-decorator';
+
+@Component
+export default class InstructionsIcon extends Vue {}
 </script>
 
 <style lang="stylus" scoped>


### PR DESCRIPTION
Because:
- code should be easy to read and interpret without complete insight
- types give clear hints about objects

this commit will:
- rename public variable to make it easier to interpret out of context
- change component to use class syntax for better typing