### PR TITLE
fix: Remove duplicate security policy link on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,3 @@ contact_links:
   - name: Ask a question
     url: https://github.com/nodepa/seedling/discussions/new
     about: Ask and discuss questions with other Seedling community members
-  - name: Report Security Vulnerabilities
-    url: https://github.com/nodepa/seedling/blob/main/.github/SECURITY.md
-    about: Please report security vulnerabilities here.


### PR DESCRIPTION
**Motivation - Why is this change necessary?**
Because:
- the GitHub New Issue dialog shows two nearly identical links
  to the security policy
- both links provide the same functionality
- GitHub adds one of the links when a SECURITY.md file exits
- the other link was added explicitly through a config

**Impact - How will this commit address the need?**
this commit will:
- remove the security policy link from the relevant config
- keep the SECURITY.md file that triggers GitHub to keep the other link

**Issues - What issues are involved?**
Closes #174

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](
  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>
