### PR TITLE
docs: Prettify sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@
 #liberapay: # Replace with a single Liberapay username
 #issuehunt: # Replace with a single IssueHunt username
 #otechie: # Replace with a single Otechie username
-custom: ['https://www.nodepa.org/donations']
+custom: ['nodepa.org/donations']


### PR DESCRIPTION
Because supporters should get a smooth and good experience,

this commit will:
- change the sponsor link to a prettier format

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I agree to license these contributions to the public under Seedling's
  [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>