### PR TITLE
docs: Change docs theme

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,4 @@
-title: "Seedling Documentation"
-remote_theme: pmarsceill/just-the-docs
+title: "Global Seedling"
+remote_theme: "mmistakes/minimal-mistakes"
+plugins:
+  - jekyll-include-cache


### PR DESCRIPTION
Because the docs should serve as a portal to the project
including documentation

this commit will:
- change the Jekyll theme to "Minimal Mistakes" for more flexibility

**Certification**
- [x] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I agree to license these contributions to the public under Seedling's
  [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>