### PR TITLE
docs: Reformat license file

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -18,8 +18,8 @@ Resolves #23
 - [ ] I certify that <!-- Check the box to certify: [X] -->
 - I have read the [contributing guidelines](
   https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
-- I agree to license these contributions to the public under Seedling's
-  [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
+- I license these contributions to the public under Seedling's [LICENSE](
+  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
   and have the rights to do so.
 
 # Signed-off-by: Name/username <email>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,9 +1,3 @@
-This license covers everything in the Seedling project
-EXCEPT all material in the [content/](content/) folder,
-which is covered by a
-[Creative Commons Attribution-ShareAlike 4.0 International Public License](
-content/LICENSE.md).
-
 MIT License
 
 Copyright (c) 2020-2021 Norwegian Development Partners

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,7 +20,6 @@
 
 logo: assets/images/seedling-logo-blue.svg
 title: Seedling
-subtitle: Modern mobile multi-language literacy
 description: >- # this means to ignore newlines until next yaml entry
   Seedling is a first-language digital learning tool for adults;
   a collection of literacy exercises that bundled content can make use of


### PR DESCRIPTION
Because having two licenses in the base LICENSE file confuses GitHub,
and it's recommended to note multiple licenses in the README anyway,

this commit will:
- reformat the base LICENSE file to only quote the MIT license

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](
  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>
