### PR TITLE
docs: Remove ad-blocker trigger

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,7 +20,7 @@
 
 logo: assets/images/seedling-logo-blue.svg
 title: Seedling
-description: >- # this means to ignore newlines until next yaml entry
+description: >- # ignore newlines until next yaml entry
   Seedling is a first-language digital learning tool for adults;
   a collection of literacy exercises that bundled content can make use of
   to provide lessons to learners unfamiliar with reading
@@ -33,6 +33,7 @@ footer:
   links:
     - label: Privacy policy
       url: "privacy-policy"
+      icon: none
 
 defaults:
   # _pages

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,5 +1,5 @@
 <div class="page__footer-follow">
-  <ul class="social-icons">
+  <ul>
     {% if site.data.ui-text[site.locale].follow_label %}
       <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
     {% endif %}


### PR DESCRIPTION
Because users may be using ad-blockers,
and at least some ad-blockers hide the link to the privacy policy,

this commit will:
- remove the identifier that triggers the ad-blocker
- remove the icon on the privacy policy link

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](
  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>