### PR TITLE
docs: Fix privacy link when on sub-page

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -32,7 +32,7 @@ atom_feed:
 footer:
   links:
     - label: Privacy policy
-      url: "privacy-policy"
+      url: "/privacy-policy"
       icon: none
 
 defaults:


### PR DESCRIPTION
Because the privacy link is relative,
it does not reach the actual url when showing a sub-page.

This commit will:
- make the privacy link absolute

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](
  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>