### PR TITLE
docs: Fix reference to documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ https://docs.github.com/en/github/site-policy/github-community-guidelines).
   in [Seedling discussions](https://github.com/nodepa/seedling/discussions).
   Please stop by and say hi.
 - Explore the project *documentation*
-  in the [docs/](/docs) folder of the code repository.
+  at [GlobalSeedling - Get started](https://globalseedling.com/get-started).
 - Inspect the *nuts and bolts* of Seedling
   by cloning the [repository](https://github.com/nodepa/seedling).
   See the README-section on [Development setup](../README.md#development-setup)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <br/>
 <p align="center">
-  <a href="/docs/index.md">Documentation</a>
+  <a href="https://globalseedling.com/get-started">Documentation</a>
   ·
   <a href="/.github/CONTRIBUTING.md">Contributing</a>
 </p>
@@ -73,34 +73,62 @@ available at [种字.com](https://种字.com)
 
 ### Development setup
 
+#### Clone the Seedling repository
+
 ```sh
-# Clone the Seedling repository
 git clone git@github.com:nodepa/seedling.git
+```
 
-# Navigate to repo
+#### Navigate to repo
+
+```sh
 cd seedling/app
+```
 
-# Install recommended project version of Node & NPM
-# If you do not have NVM installed,
-# install Node.js according to your preference,
-# but use the version specified in the project's .nvmrc file.
-# If you do have NVM installed, it will use the .nvmrc version:
+#### Install Node & NPM
+
+If you do not have NVM installed,
+install Node.js according to your preference,
+but *use the version specified in the project's `.nvmrc` file*.
+If you do have NVM installed, these commands will use the `.nvmrc` version:
+
+```sh
 nvm install
 nvm use
+```
 
-# Install packages
+#### Install packages
+
+```sh
 npm install
+```
 
-# Start the app in local demo
+#### Start the app in local demo
+
+```sh
 npm start   # Then visit http://localhost:8080 in your web browser
+```
 
-# Run full test suite (scripts for install & lint & test:unit:coverage & test:e2e)
+#### Run full test suite
+
+This is a command that combines the scripts for
+
+- install
+- lint
+- test:unit:coverage
+- test:e2e
+
+```sh
 npm run verify
 ```
 
+### Misc
+
 Play around with your own content
-by replacing the `content/` folder with your own.
-See the [Seedling documentation](/docs/index.md) about formats.
+by replacing the `content/` folder (parallel to the `app/` folder)
+with your own.
+See the [Seedling documentation](https://globalseedling.com/get-started)
+about formats.
 
 ## Community
 


### PR DESCRIPTION
Because GlobalSeedling.com is live with the documentation for Seedling

this commit will:
- update documentation references to refer to GlobalSeedling.com

Resolves #69

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](
  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>