### PR TITLE
refactor: Fix path to content ref in comment

### DIFF
--- a/app/src/Lessons/ContentPackTypes.ts
+++ b/app/src/Lessons/ContentPackTypes.ts
@@ -1,9 +1,9 @@
 export interface PackageConfig {
   formatVersion: string;
   // All instruction paths must be relative paths
-  // starting from Lessons/data/:
+  // starting from <project root>/content/:
   // some/audio/path.mp3
-  // will be used to resolve: app/src/Lessons/data/some/audio/path.mp3
+  // will be used to resolve: <project root>/content/some/audio/path.mp3
   instructions: {
     welcome: string;
     homeButton: string;


### PR DESCRIPTION
Because the outdated comment may confuse content devs,

this commit will:
- amend the comment to reference the correct path to content

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](
  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>