### PR TITLE
fix: Bump jsonpointer to 5.0.0 for security

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12608,9 +12608,9 @@
       }
     },
     "node_modules/jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -18394,7 +18394,7 @@
       "dev": true,
       "dependencies": {
         "json-schema": "^0.3.0",
-        "jsonpointer": "^4.1.0",
+        "jsonpointer": "^5.0.0",
         "leven": "^3.1.0"
       },
       "engines": {
@@ -28421,9 +28421,9 @@
       }
     },
     "jsonpointer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
-      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.0.tgz",
+      "integrity": "sha512-PNYZIdMjVIvVgDSYKTT63Y+KZ6IZvGRNNWcxwD+GNnUz1MKPfv30J8ueCjdwcN0nDx2SlshgyB7Oy0epAzVRRg==",
       "dev": true
     },
     "jsprim": {
@@ -32783,7 +32783,7 @@
           "dev": true,
           "requires": {
             "json-schema": "^0.3.0",
-            "jsonpointer": "^4.1.0",
+            "jsonpointer": "^5.0.0",
             "leven": "^3.1.0"
           }
         },


### PR DESCRIPTION
Because users should be protected from the consequences of using
insecure dependencies,

this commit will:
- bump jsonpointer to 5.0.0

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](
  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>