### PR TITLE
docs: Fix missing .nojekyll and changed image path

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,4 +1,4 @@
 # Seedling Support
 
-- [Developer documentation](https://github.com/nodepa/seedling/tree/main/docs/)
+- [Developer documentation](https://globalseedling.com/get-started/get-started)
 - [Seedling discussions](https://github.com/nodepa/seedling/discussions)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,7 @@ jobs:
           target_branch: gh-pages
           # deploy the default output dir of VuePress
           build_dir: docs/.vuepress/dist
+          nojekyll: true
         env:
           # @see https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Seedling</h1>
 
 <p align="center">
-  <img src="docs/assets/images/seedling-logo-blue.svg"
+  <img src="docs/.vuepress/public/images/seedling-logo-blue.svg"
     alt="seedling-logo" height="160px" width="160px"/>
   <br/>
   <b>Modern mobile multi-language literacy</b>


### PR DESCRIPTION
Because switching to Vuepress came with a few hicups,

this commit will:
- add configuration to deploy a .nojekyll file
  to prevent Github from running the default Jekyll workflow
- update the path to the logo since doc-assets live elsewhere now
- update support-documentation
  to direct doc-seekers to globalseedling.com

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](
  https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>