### PR TITLE
docs: Update readme links to globalseedling.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 <br/>
 <p align="center">
-  <a href="https://globalseedling.com/get-started">Documentation</a>
+  <a href="https://globalseedling.com/get-started/get-started.html">Documentation</a>
   ·
   <a href="/.github/CONTRIBUTING.md">Contributing</a>
 </p>
@@ -127,7 +127,7 @@ npm run verify
 Play around with your own content
 by replacing the `content/` folder (parallel to the `app/` folder)
 with your own.
-See the [Seedling documentation](https://globalseedling.com/get-started)
+See the [Seedling documentation](https://globalseedling.com/get-started/get-started.html)
 about formats.
 
 ## Community


### PR DESCRIPTION
Because contributors should have easy access to correct documentation,

this commit will:
- fix the links from the README to globalseedling.com docs

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>