### PR TITLE
infra: Re-add commitlint body-leading-blank

### DIFF
--- a/app/commitlint.config.js
+++ b/app/commitlint.config.js
@@ -33,6 +33,7 @@ module.exports = {
     'body-empty': [2, 'never'],
     'body-footer-certification': [2, 'always'],
     'body-impact': [1, 'always'],
+    'body-leading-blank': [2, 'always'],
     'body-max-line-length': [2, 'always', 72],
     'body-motivation': [1, 'always'],
     'footer-leading-blank': [2, 'always'],
@@ -56,6 +57,29 @@ module.exports = {
   plugins: [
     {
       rules: {
+        'body-leading-blank': (parsed, when) => {
+          if (!parsed.body) {
+            return [true];
+          }
+          const negated = when === 'never';
+          const lines = parsed.raw.split(/(?:\r?\n)/).slice(1);
+          let firstNonCommentIsBlank = false;
+          for (const line of lines) {
+            if (line === '') {
+              firstNonCommentIsBlank = true;
+              break;
+            }
+            if (!line.match(/^#+/)) {
+              break;
+            }
+          }
+          return [
+            negated ? !firstNonCommentIsBlank : firstNonCommentIsBlank,
+            'body ' + negated
+              ? 'may not '
+              : 'must ' + 'have leading blank line',
+          ];
+        },
         'body-footer-certification': function (
           { body, footer },
           when = 'always',


### PR DESCRIPTION
Because commitlint's body-leading-blank rule doesn't account for comments as possible lines between header and body,

this commit will:
- add a custom plugin rule that checks if the first lines after the header are either comments or blanks, ensuring that there are at least one blank before the body proper.

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>