### PR TITLE
infra: Update templates for commit messages and pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,14 @@
 <!-- If this pull request contains a single commit,
 there should already be a pull request TITLE and MESSAGE above ^^^.
 If they differ significantly from the template below,
-please (re-)write the pull request accordingly:
+please (re-)write the pull request according to:
 https://github.com/nodepa/seedling/blob/main/.gitmessage
 
 TITLE format:
 feat: Add feature (use imperative mood)
   └── feat, fix, refactor, style, docs, test, content or infra
 
-MESSAGE format: -->
+MESSAGE format:
 **Motivation - Why is this change necessary?**
 Because
 
@@ -16,19 +16,18 @@ Because
 this commit will:
 - add
 
-**Context - Additional information** <!-- Optional section -->
+**Context - Additional information**
 
 **Issues - What issues are involved?**
 Resolves #12
 Resolves #23
 
 **Certification**
-- [ ] I certify that <!-- Check the box to certify: [X] -->
+- [ ] I certify that <-- Check the box to certify: [X]
 - I have read the [contributing guidelines](
   https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
-- I agree to license these contributions to the public under Seedling's
+- I license these contributions to the public under Seedling's
   [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
   and have the rights to do so.
 
-Signed-off-by:
-<!-- Signed-off-by: gituser <email@address.com> -->
+Signed-off-by: Name/username <email>

--- a/.gitmessage
+++ b/.gitmessage
@@ -44,7 +44,7 @@ Resolves #23
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
 #   https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
-# - I agree to license these contributions to the public under Seedling's
+# - I license these contributions to the public under Seedling's
 #   [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
 #   and have the rights to do so.
 #
@@ -66,7 +66,7 @@ Resolves #23
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
 #   https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
-# - I agree to license these contributions to the public under Seedling's
+# - I license these contributions to the public under Seedling's
 #   [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
 #   and have the rights to do so.
 #
@@ -89,7 +89,7 @@ Resolves #23
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
 #   https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
-# - I agree to license these contributions to the public under Seedling's
+# - I license these contributions to the public under Seedling's
 #   [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
 #   and have the rights to do so.
 #
@@ -115,7 +115,7 @@ Resolves #23
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
 #   https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
-# - I agree to license these contributions to the public under Seedling's
+# - I license these contributions to the public under Seedling's
 #   [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
 #   and have the rights to do so.
 #
@@ -142,7 +142,7 @@ Resolves #23
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
 #   https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
-# - I agree to license these contributions to the public under Seedling's
+# - I license these contributions to the public under Seedling's
 #   [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
 #   and have the rights to do so.
 #

--- a/app/commitlint.config.js
+++ b/app/commitlint.config.js
@@ -28,14 +28,14 @@
 // # ─── END OF COMMIT MESSAGE ───────────────────────────────────wrap<=72┘
 module.exports = {
   helpUrl:
-    "Check the .gitmessage file in the project's base directory for a commit message template",
+    "Commit message guidelines are found in this project's root folder's .gitmessage file, and at https://github.com/nodepa/seedling/blob/main/.gitmessage",
   rules: {
     'body-empty': [2, 'never'],
     'body-footer-certification': [2, 'always'],
-    'body-impact': [1, 'always'],
+    'body-impact': [1, 'always'], // 1 means warning
     'body-leading-blank': [2, 'always'],
     'body-max-line-length': [2, 'always', 72],
-    'body-motivation': [1, 'always'],
+    'body-motivation': [1, 'always'], // 1 means warning
     'footer-leading-blank': [2, 'always'],
     'footer-max-line-length': [2, 'always', 72],
     'header-max-length': [2, 'always', 72],
@@ -98,16 +98,17 @@ module.exports = {
             );
           return [
             negated ? !includesCertification : includesCertification,
-            `Your commit message MUST ${
-              negated ? 'NOT ' : ''
-            }contain a certification with a box checked with an X, like this:\n\n` +
-              '**Certification**\n' +
-              '- [X] I certify that <!-- Check the box to certify: [X] -->\n' +
-              '- I have read the [contributing guidelines](\n' +
-              '  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)\n' +
-              "- I license these contributions to the public under Seedling's\n" +
-              '  [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)\n' +
-              '  and have the rights to do so.\n\n',
+            'body ' + negated
+              ? 'may not  '
+              : 'must ' +
+                'contain a certification with a box checked with an X, like this:\n\n' +
+                '**Certification**\n' +
+                '- [X] I certify that <!-- Check the box to certify: [X] -->\n' +
+                '- I have read the [contributing guidelines](\n' +
+                '  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)\n' +
+                "- I license these contributions to the public under Seedling's\n" +
+                '  [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)\n' +
+                '  and have the rights to do so.\n\n',
           ];
         },
         // # **Motivation - Why is this change necessary?**
@@ -117,9 +118,10 @@ module.exports = {
           const includesMotivation = body.includes('Because ');
           return [
             negated ? !includesMotivation : includesMotivation,
-            `Your commit message MUST ${
-              negated ? 'NOT ' : ''
-            }contain a line of motivation explaining the rationale for the commit by answering "Why is this change necessary?", starting with "Because "\n`,
+            'body ' + negated
+              ? 'may not  '
+              : 'must ' +
+                'contain a line of motivation explaining the rationale for the commit by answering "Why is this change necessary?", starting with "Because "\n',
           ];
         },
         // # **Impact - How will this commit address the need?**
@@ -132,9 +134,10 @@ module.exports = {
             .includes('this commit will');
           return [
             negated ? !includesImpact : includesImpact,
-            `Your commit message MUST ${
-              negated ? 'NOT ' : ''
-            }contain a line of impact explaining the result of the commit by answering "How will this commit address the need?", starting with "this commit will "\n`,
+            'body ' + negated
+              ? 'may not  '
+              : 'must ' +
+                'contain a line of impact explaining the result of the commit by answering "How will this commit address the need?", starting with "this commit will "\n',
           ];
         },
       },


### PR DESCRIPTION
Because having to delete pull request template text when creating a PR on GitHub is slow and cumbersome, yet it has been necessary due to the structure of the PR template, and because consistency between commit message template, commitlint rules, PR template and commit message examples reduces developer friction by managing developer expectations better,

this commit will:
- upate the PR template and make all of it a comment, so that forgetting to delete it will leave it not rendered on GitHub, while leaving guidance that can be uncommented if needed
- update the .gitmessage commit message template with consistent certification language
- update commitlint.config.js with better phrasing

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>