### PR TITLE
docs: Add instructions to download Android app

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@
 
 ## What is Seedling
 
-Seedling is a first-language digital learning tool for adults;
-a collection of literacy exercises
-that bundled content can make use of
-to provide lessons to learners
-unfamiliar with reading the particular content language.
+Seedling is a digital language learning tool for adults.
+
+A teacher or content developer
+can prepare lessons of curated exercises
+using Seedling's included exercise templates
+to provide tailored exercises
+to someone who is learning to read their native first-language.
 
 Current exercise types are:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,17 +38,24 @@ footer: '<a href="/privacy-policy/privacy-policy.html">Privacy policy</a><br/><b
 
 ## What is Seedling?
 
-Seedling is a digital learning tool for adults;
-a collection of exercise templates
-that bundled content can use
-to present curated lessons
-for first-language learners.
+Seedling is a digital language learning tool for adults.
+
+A teacher or content developer
+can prepare lessons of curated exercises
+using Seedling's included exercise templates
+to provide tailored exercises
+to someone who is learning to read their native first-language.
 
 [Li Ai Education](https://liaieducation.com) used Seedling
 to make [立爱种字](https://种字.com),
 to help [Standard Chinese (Putonghua)](
   https://en.wikipedia.org/wiki/Standard_Chinese) speaking adults
 learn to read simplified Chinese characters.
+
+You can try the Android app by downloading [version 0.95.0](https://github.com/nodepa/seedling/releases/download/v0.95.0/zz.v0.95.0_7.apk) or [check for a more recent release](https://github.com/nodepa/seedling/releases).
+
+You may have to enable "Installation from unknown sources"
+in the settings of your phone to be able to install.
 
 ## Get involved
 


### PR DESCRIPTION
Because content developers and users should have easy access to the app

this commit will:
- add instructions on how to download the Android app for a fully offline experience

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.

Signed-off-by: toshify <4579559+toshify@users.noreply.github.com>
