### PR TITLE
docs: Update docs deployment workflow actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,20 +17,20 @@ jobs:
 
     steps:
       - name: Fetch repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # fetch all commits to get last updated time or other git log info
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           # choose node.js version to use
-          node-version: '14'
+          node-version: 'lts/*'
 
       # cache node_modules
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: npm-cache
         with:
           path: ~/.npm

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
-        "@vuepress/plugin-docsearch": "^2.0.0-beta.61",
-        "vuepress": "^2.0.0-beta.61"
+        "@vuepress/plugin-docsearch": "^2.0.0-beta.67",
+        "vuepress": "^2.0.0-beta.67"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
@@ -672,16 +672,6 @@
         "markdown-it": "^13.0.1"
       }
     },
-    "node_modules/@mdit-vue/plugin-component/node_modules/@types/markdown-it": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.0.tgz",
-      "integrity": "sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
-      }
-    },
     "node_modules/@mdit-vue/plugin-frontmatter": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-frontmatter/-/plugin-frontmatter-0.12.1.tgz",
@@ -692,16 +682,6 @@
         "@types/markdown-it": "^13.0.0",
         "gray-matter": "^4.0.3",
         "markdown-it": "^13.0.1"
-      }
-    },
-    "node_modules/@mdit-vue/plugin-frontmatter/node_modules/@types/markdown-it": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.0.tgz",
-      "integrity": "sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
       }
     },
     "node_modules/@mdit-vue/plugin-headers": {
@@ -716,16 +696,6 @@
         "markdown-it": "^13.0.1"
       }
     },
-    "node_modules/@mdit-vue/plugin-headers/node_modules/@types/markdown-it": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.0.tgz",
-      "integrity": "sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
-      }
-    },
     "node_modules/@mdit-vue/plugin-sfc": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-sfc/-/plugin-sfc-0.12.1.tgz",
@@ -735,16 +705,6 @@
         "@mdit-vue/types": "0.12.0",
         "@types/markdown-it": "^13.0.0",
         "markdown-it": "^13.0.1"
-      }
-    },
-    "node_modules/@mdit-vue/plugin-sfc/node_modules/@types/markdown-it": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.0.tgz",
-      "integrity": "sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
       }
     },
     "node_modules/@mdit-vue/plugin-title": {
@@ -759,16 +719,6 @@
         "markdown-it": "^13.0.1"
       }
     },
-    "node_modules/@mdit-vue/plugin-title/node_modules/@types/markdown-it": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.0.tgz",
-      "integrity": "sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
-      }
-    },
     "node_modules/@mdit-vue/plugin-toc": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-toc/-/plugin-toc-0.12.1.tgz",
@@ -781,16 +731,6 @@
         "markdown-it": "^13.0.1"
       }
     },
-    "node_modules/@mdit-vue/plugin-toc/node_modules/@types/markdown-it": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.0.tgz",
-      "integrity": "sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
-      }
-    },
     "node_modules/@mdit-vue/shared": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@mdit-vue/shared/-/shared-0.12.1.tgz",
@@ -800,16 +740,6 @@
         "@mdit-vue/types": "0.12.0",
         "@types/markdown-it": "^13.0.0",
         "markdown-it": "^13.0.1"
-      }
-    },
-    "node_modules/@mdit-vue/shared/node_modules/@types/markdown-it": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.0.tgz",
-      "integrity": "sha512-mPTaUl5glYfzdJFeCsvhXQwZKdyszNAZcMm5ZTP5SfpTu+vIbog7J3z8Fa4x/Fzv5TB4R6OA/pHBYIYmkYOWGQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
       }
     },
     "node_modules/@mdit-vue/types": {
@@ -924,15 +854,15 @@
       }
     },
     "node_modules/@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-pTjcqY9E4nOI55Wgpz7eiI8+LzdYnw3qxXCfHyBDdPbYvbyLgWLJGh8EdPvqawwMK1Uo1794AUkkR38Fr0g+2g==",
       "dev": true
     },
     "node_modules/@types/markdown-it": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-SUEb8Frsxs3D5Gg9xek6i6EG6XQ5s+O+ZdQzIPESZVZw3Pv3CPQfjCJBI+RgqZd1IBeu18S0Rn600qpPnEK37w==",
       "dev": true,
       "dependencies": {
         "@types/linkify-it": "*",
@@ -961,9 +891,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.6.tgz",
-      "integrity": "sha512-Gi5wRGPbbyOTX+4Y2iULQ27oUPrefaB0PxGQJnfyWN3kvEDGM3mIB5M/gQLmitZf7A9FmLeaqxD3L1CXpm3VKQ==",
+      "version": "20.5.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.9.tgz",
+      "integrity": "sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==",
       "dev": true
     },
     "node_modules/@types/web-bluetooth": {
@@ -973,9 +903,9 @@
       "dev": true
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.3.3.tgz",
-      "integrity": "sha512-ssxyhIAZqB0TrpUg6R0cBpCuMk9jTIlO1GNSKKQD6S8VjnXi6JXKfUXjSsxey9IwQiaRGsO1WnW9Rkl1L6AJVw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-4.3.4.tgz",
+      "integrity": "sha512-ciXNIHKPriERBisHFBvnTbfKa6r9SAesOYXeGDzgegcvy9Q4xdScSHAmKbNT0M3O0S9LKhIf5/G+UYG4NnnzYw==",
       "dev": true,
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -1104,88 +1034,88 @@
       "dev": true
     },
     "node_modules/@vuepress/bundler-vite": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/bundler-vite/-/bundler-vite-2.0.0-beta.66.tgz",
-      "integrity": "sha512-qX/ROiieQYggGXz/NCr3i9okcuRdSPizUn/RqDWT26gGqLLtX/qab8/+LJrQ8WMN5XqrSYsSvbY8W3jb1Iu7tw==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/bundler-vite/-/bundler-vite-2.0.0-beta.67.tgz",
+      "integrity": "sha512-W6YXixxu2G+xPECPFvx4Tzv5fmpBYvApEYVw7qfSNf/5YZ6aeIfV0AMGJZvhk7R/KniofvBTGCjAMSK4fqKp8w==",
       "dev": true,
       "dependencies": {
-        "@vitejs/plugin-vue": "^4.2.3",
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
-        "autoprefixer": "^10.4.14",
+        "@vitejs/plugin-vue": "^4.3.3",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
+        "autoprefixer": "^10.4.15",
         "connect-history-api-fallback": "^2.0.0",
-        "postcss": "^8.4.25",
+        "postcss": "^8.4.28",
         "postcss-load-config": "^4.0.1",
-        "rollup": "^3.26.2",
-        "vite": "~4.4.2",
+        "rollup": "^3.28.1",
+        "vite": "~4.4.9",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
       }
     },
     "node_modules/@vuepress/cli": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/cli/-/cli-2.0.0-beta.66.tgz",
-      "integrity": "sha512-VWOAxjePlxeao/6ecg1AQrrnbtgDJ0VOyYX3Zx2r2vwD0lBDE8OCtJUjP2X+3g2H8bauY4utM7rqWqm7yHC1og==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/cli/-/cli-2.0.0-beta.67.tgz",
+      "integrity": "sha512-OWd5JMq9pEHrz2MTTQV91EoG+7o18s1JWKP7GBfYQ2DRAu/Hf4rZPmluuibhFolTvnTDuTtXrfb6Wbx4iZ+M9Q==",
       "dev": true,
       "dependencies": {
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "cac": "^6.7.14",
         "chokidar": "^3.5.3",
         "envinfo": "^7.10.0",
-        "esbuild": "~0.18.11"
+        "esbuild": "~0.18.20"
       },
       "bin": {
         "vuepress-cli": "bin/vuepress.js"
       }
     },
     "node_modules/@vuepress/client": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-beta.66.tgz",
-      "integrity": "sha512-WjrL1u0NOVUwiGoVOIfQqSU7SwzJUkyBFu3xiZoNmWFD9VdPIfuSRvVeZDhr+br/0tA7XrJd2ueSEDt5+BM3Qg==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-beta.67.tgz",
+      "integrity": "sha512-xfXZXmZmMbCvQxUhNltuAZzpoiwM0x9ke+DdPPDBF0oGMNDlmtOlsD7NcH322vQE3ehYy5mXJttXuEmfoNOG6A==",
       "dev": true,
       "dependencies": {
         "@vue/devtools-api": "^6.5.0",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vueuse/core": "^10.2.1",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vueuse/core": "^10.4.1",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
       }
     },
     "node_modules/@vuepress/core": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.66.tgz",
-      "integrity": "sha512-CPvm6BR5zpvKeky9Z9QbAzsDHTrrxEXFKvN5MUsdEKUTPfoumI1dDT2O6eQS37X9jNB+6mckFaPWKQncbaW1Bg==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.67.tgz",
+      "integrity": "sha512-pbCm1x+zFKZqpJjS68sv3ziEQLMn0KM04Q6W249stcTUUBrKox2OPx+OcX/BrN6yH60OviXN8hD6MgCnFSWdZA==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/markdown": "2.0.0-beta.66",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/markdown": "2.0.0-beta.67",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "vue": "^3.3.4"
       }
     },
     "node_modules/@vuepress/markdown": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.66.tgz",
-      "integrity": "sha512-Zj4THYy6qsw3S9ROoNRy+o4i/4WyYhXKsDEM1v0N0/WJ0DMeHZORDlBPnq7dKwEqtyv42iLz9D2SYI7T3ADs/A==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.67.tgz",
+      "integrity": "sha512-dwciE7dbfDruLan+w9x/LUl5dLdBWB39QXznX/Hhv4oPp+Mm4as53J58gqjuRPi6N25DfRi3ODrzjG5Lduwnfw==",
       "dev": true,
       "dependencies": {
-        "@mdit-vue/plugin-component": "^0.12.0",
-        "@mdit-vue/plugin-frontmatter": "^0.12.0",
-        "@mdit-vue/plugin-headers": "^0.12.0",
-        "@mdit-vue/plugin-sfc": "^0.12.0",
-        "@mdit-vue/plugin-title": "^0.12.0",
-        "@mdit-vue/plugin-toc": "^0.12.0",
-        "@mdit-vue/shared": "^0.12.0",
+        "@mdit-vue/plugin-component": "^0.12.1",
+        "@mdit-vue/plugin-frontmatter": "^0.12.1",
+        "@mdit-vue/plugin-headers": "^0.12.1",
+        "@mdit-vue/plugin-sfc": "^0.12.1",
+        "@mdit-vue/plugin-title": "^0.12.1",
+        "@mdit-vue/plugin-toc": "^0.12.1",
+        "@mdit-vue/shared": "^0.12.1",
         "@mdit-vue/types": "^0.12.0",
-        "@types/markdown-it": "^12.2.3",
+        "@types/markdown-it": "^13.0.1",
         "@types/markdown-it-emoji": "^2.0.2",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "markdown-it": "^13.0.1",
         "markdown-it-anchor": "^8.6.7",
         "markdown-it-emoji": "^2.0.2",
@@ -1193,156 +1123,156 @@
       }
     },
     "node_modules/@vuepress/plugin-active-header-links": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-2.0.0-beta.66.tgz",
-      "integrity": "sha512-f0T1LK0oWFJ/tuOg7+F3mCT2tzqu1PcKhTlF5wtkZzn8YdGtlpr9X7jX4owrbqMwlbYLbaCER1AeoH31eKA7Ow==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-2.0.0-beta.67.tgz",
+      "integrity": "sha512-2AxtFnnvHn750x+dCFbCWgqxpS+zsNucw8vuATmyRiBAleEqfM1Wz+RuMSKBM38GxsI/7mnQgWOgqj4S90G+ZA==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "ts-debounce": "^4.0.0",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
       }
     },
     "node_modules/@vuepress/plugin-back-to-top": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-2.0.0-beta.66.tgz",
-      "integrity": "sha512-tmBe7h3uosQcAko1dmqUYjMUdIBxSE7nMbKAsHb8/GX77HWLOM5SaOKye++vPWu/1HMkZwU/iwI2njdC6fSTYw==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-2.0.0-beta.67.tgz",
+      "integrity": "sha512-ystolf429cvAfX4qw1o9sHfkB8+KdQ4rV8P4ILR5LERgTZprL+1FbQfcHgVjEF2p0UKu2QXJQNGx2LfWWVuYdw==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "ts-debounce": "^4.0.0",
         "vue": "^3.3.4"
       }
     },
     "node_modules/@vuepress/plugin-container": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-container/-/plugin-container-2.0.0-beta.66.tgz",
-      "integrity": "sha512-/R8NlDz18co9qXoYjarJA+kIFWFNrhE1+Xd1WSgcUZw5WoQydz19MTPDJICmiHQBGZjm2EgnWbyNZFpk6BcsPQ==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-container/-/plugin-container-2.0.0-beta.67.tgz",
+      "integrity": "sha512-NuxjNkyJ2bYsRpw3iAiok2aeKYzZQsEZ8A/i+4LYwrDXbj3HfjlDhfPYhN+BMQfbxE9LpXOG0APNcXVCNMu0hw==",
       "dev": true,
       "dependencies": {
-        "@types/markdown-it": "^12.2.3",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/markdown": "2.0.0-beta.66",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@types/markdown-it": "^13.0.1",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/markdown": "2.0.0-beta.67",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "markdown-it": "^13.0.1",
         "markdown-it-container": "^3.0.0"
       }
     },
     "node_modules/@vuepress/plugin-docsearch": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-docsearch/-/plugin-docsearch-2.0.0-beta.66.tgz",
-      "integrity": "sha512-gUNejbv00wT5uK6fJvlbKGMN9NhFSMqb6lmSH+9s+4z78sD6hwhpkC7PZry3DlzcvbZstrGHqbfnn3NLhyhSzQ==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-docsearch/-/plugin-docsearch-2.0.0-beta.67.tgz",
+      "integrity": "sha512-s1lvIfEN5U7wzNpCLjIUIkHMdrBp4GzogJ+KM0LDNB56NE3DJf2brTB+UbGbcHCe8ispkTqCOXgHAbVFMPKv/Q==",
       "dev": true,
       "dependencies": {
-        "@docsearch/css": "^3.5.1",
-        "@docsearch/js": "^3.5.1",
-        "@docsearch/react": "^3.5.1",
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
-        "@vueuse/core": "^10.2.1",
+        "@docsearch/css": "^3.5.2",
+        "@docsearch/js": "^3.5.2",
+        "@docsearch/react": "^3.5.2",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
+        "@vueuse/core": "^10.4.1",
         "ts-debounce": "^4.0.0",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
       }
     },
     "node_modules/@vuepress/plugin-external-link-icon": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-external-link-icon/-/plugin-external-link-icon-2.0.0-beta.66.tgz",
-      "integrity": "sha512-kkOMhtJSVkjN4ncaEKxoZ9pzlIrQvEYh2W66H1Mgb4TdnN4P+IDvIbTaMLlD5SaUnS/yF7YiLLtsMtKH0z0oyA==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-external-link-icon/-/plugin-external-link-icon-2.0.0-beta.67.tgz",
+      "integrity": "sha512-JD0/Uvt1WQXiGoAA0pjpqQ7OINDUm1TSgWeIpfPq9tZJNfgjmqUoartMFUuqcvl4eMi4Alfx0dWkzSF9qHL7Pg==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/markdown": "2.0.0-beta.66",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/markdown": "2.0.0-beta.67",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "vue": "^3.3.4"
       }
     },
     "node_modules/@vuepress/plugin-git": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-beta.66.tgz",
-      "integrity": "sha512-IOCoOIPwbAmxXr6clf9BRyv0lsgR1G9CAkzM7PkrBSeW7QSxh9skfSsNFNSe1vhjNyQGETq+Ebjfje8Y8p0qjA==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-beta.67.tgz",
+      "integrity": "sha512-9JSGmEtDqBWEmszqEE7spBjWdbeZo0jeMi2ZQLT4KgQrYh5fU/DO8MgeJxGXXd9xvpz4aVAzQR+gqYpL6kO5Jw==",
       "dev": true,
       "dependencies": {
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
-        "execa": "^7.1.1"
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
+        "execa": "^8.0.1"
       }
     },
     "node_modules/@vuepress/plugin-medium-zoom": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-medium-zoom/-/plugin-medium-zoom-2.0.0-beta.66.tgz",
-      "integrity": "sha512-ND7Cbzu0YOHo4Tclin9yXhs6r9qI8SkfW2guOjy+qXpnN0Yl1uo3xJQwiAlkEmt7AdYNUE6wtia/qz8Bs+GqBA==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-medium-zoom/-/plugin-medium-zoom-2.0.0-beta.67.tgz",
+      "integrity": "sha512-KLXfzKKbAhLSaRdbkHlvpbpYtaqINYBJ9gB4Q7CQ5AUaA8uStLG6rX0RjyhKAONfIJWuFiVYCp38QSI++fa/tA==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "medium-zoom": "^1.0.8",
         "vue": "^3.3.4"
       }
     },
     "node_modules/@vuepress/plugin-nprogress": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-2.0.0-beta.66.tgz",
-      "integrity": "sha512-ouvT76xs4ETXGcYzh9cY40l5grVeWEPNQX3ddcbsC240R1VIs0mv4oyb80p6h27TSyzs++SgxwESTxnEzBSFtg==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-2.0.0-beta.67.tgz",
+      "integrity": "sha512-BlqALWsNCllrqhMgRGz+50ah984XCwp1wejNYGP0ENEGSo1SY2dUI4AatIWep4Zj+0s7gbBR0swZc49hkLpENg==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
       }
     },
     "node_modules/@vuepress/plugin-palette": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-palette/-/plugin-palette-2.0.0-beta.66.tgz",
-      "integrity": "sha512-Ukt9NbCBo9Uvo6ALim0l3Qic1qPQBQ3OwGTuS7BMDM9XgMeStknziI6Pb9vW7MaQV2aWjbbxwnyZEoxSSlUKOw==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-palette/-/plugin-palette-2.0.0-beta.67.tgz",
+      "integrity": "sha512-Ea2nLx9yH4c70MUQpFXuRAD6OZNVdyVGppvNwyGswutqPkRu7km18ml4Jk767iGMAVfzmrlphd6VIUJBUJ81JQ==",
       "dev": true,
       "dependencies": {
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "chokidar": "^3.5.3"
       }
     },
     "node_modules/@vuepress/plugin-prismjs": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-prismjs/-/plugin-prismjs-2.0.0-beta.66.tgz",
-      "integrity": "sha512-dkxKb3XVmFWdCPiUJKjJXvIAL170ZN93wgqEpid+PDeEQl+PBQbNELFj+5UZNPpnvzZtdRUUpcfBtz9ZqRGMtw==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-prismjs/-/plugin-prismjs-2.0.0-beta.67.tgz",
+      "integrity": "sha512-IaTc/BHwdO/ydfcoGmqUsDI5G2rPsgffxDtHx4pogaBCF2A6X9O++hrR/YExOHwwyhaE/6c6kflJAefaHb+Arg==",
       "dev": true,
       "dependencies": {
-        "@vuepress/core": "2.0.0-beta.66",
+        "@vuepress/core": "2.0.0-beta.67",
         "prismjs": "^1.29.0"
       }
     },
     "node_modules/@vuepress/plugin-theme-data": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-theme-data/-/plugin-theme-data-2.0.0-beta.66.tgz",
-      "integrity": "sha512-EzDXhpG47Sc796fg1q7m3XXjD2qD+bpozRcM1aoyYP1fe/o25/q/5l8ARz9vpONuI8JvDVYmaYT3rUAh5oKstw==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-theme-data/-/plugin-theme-data-2.0.0-beta.67.tgz",
+      "integrity": "sha512-emTj1fvYXM/+WWObmgR0STRwkcDEM9QLD9ZP/JK5hEdt9KQnl8qO9NIzVfP/acgqbxFJQVvsmMSruXXknN68FQ==",
       "dev": true,
       "dependencies": {
         "@vue/devtools-api": "^6.5.0",
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
         "vue": "^3.3.4"
       }
     },
     "node_modules/@vuepress/shared": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-beta.66.tgz",
-      "integrity": "sha512-hMnFFHee6xLYVcSdpbKddcqunrOxIp2/B1gOGorcF5bZfnhJJWWsdZ//kwemAqlB8d10Z7f3x+b69Ur1LDPThw==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-beta.67.tgz",
+      "integrity": "sha512-gm8/6oAnd0Jh8g9xB89S+g8XJxt30QmeXK79J2Nwcbgy88CZnYbZssU1noyxFt4cHDX8wpUf8V5I388/dfHfoQ==",
       "dev": true,
       "dependencies": {
         "@mdit-vue/types": "^0.12.0",
@@ -1350,27 +1280,27 @@
       }
     },
     "node_modules/@vuepress/theme-default": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-2.0.0-beta.66.tgz",
-      "integrity": "sha512-5h2R1L+isDoQ0+JW8xLbR9fwUP7ysKAaWdb4+1ahXCpo5aGJRfO6S1NzUihKseut0UG7Lv3omnVVzBOh3joGNw==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-2.0.0-beta.67.tgz",
+      "integrity": "sha512-t8wfKaf/WUAifcKTYfnpsUxTVF5C4LUSiX2DH+JTt0lB/bv4SKQstuZtLvLiV9C4q2ekjGpitaW85T4KDnshug==",
       "dev": true,
       "dependencies": {
-        "@vuepress/client": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/plugin-active-header-links": "2.0.0-beta.66",
-        "@vuepress/plugin-back-to-top": "2.0.0-beta.66",
-        "@vuepress/plugin-container": "2.0.0-beta.66",
-        "@vuepress/plugin-external-link-icon": "2.0.0-beta.66",
-        "@vuepress/plugin-git": "2.0.0-beta.66",
-        "@vuepress/plugin-medium-zoom": "2.0.0-beta.66",
-        "@vuepress/plugin-nprogress": "2.0.0-beta.66",
-        "@vuepress/plugin-palette": "2.0.0-beta.66",
-        "@vuepress/plugin-prismjs": "2.0.0-beta.66",
-        "@vuepress/plugin-theme-data": "2.0.0-beta.66",
-        "@vuepress/shared": "2.0.0-beta.66",
-        "@vuepress/utils": "2.0.0-beta.66",
-        "@vueuse/core": "^10.2.1",
-        "sass": "^1.63.6",
+        "@vuepress/client": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/plugin-active-header-links": "2.0.0-beta.67",
+        "@vuepress/plugin-back-to-top": "2.0.0-beta.67",
+        "@vuepress/plugin-container": "2.0.0-beta.67",
+        "@vuepress/plugin-external-link-icon": "2.0.0-beta.67",
+        "@vuepress/plugin-git": "2.0.0-beta.67",
+        "@vuepress/plugin-medium-zoom": "2.0.0-beta.67",
+        "@vuepress/plugin-nprogress": "2.0.0-beta.67",
+        "@vuepress/plugin-palette": "2.0.0-beta.67",
+        "@vuepress/plugin-prismjs": "2.0.0-beta.67",
+        "@vuepress/plugin-theme-data": "2.0.0-beta.67",
+        "@vuepress/shared": "2.0.0-beta.67",
+        "@vuepress/utils": "2.0.0-beta.67",
+        "@vueuse/core": "^10.4.1",
+        "sass": "^1.66.1",
         "sass-loader": "^13.3.2",
         "vue": "^3.3.4",
         "vue-router": "^4.2.4"
@@ -1385,33 +1315,33 @@
       }
     },
     "node_modules/@vuepress/utils": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-beta.66.tgz",
-      "integrity": "sha512-CcgSG7ewI20iTdu1WCtQEBJiHfUgsGMg4TB4rActe9gPx8ZRoxZ8Jhr6bO3a4SU789PSBUzF7RYm9E1MtzATHg==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-beta.67.tgz",
+      "integrity": "sha512-wCK0uggm4gXroy7UkS1u8wDQmD4b0L6Gjqd/1PZTDhNlMLsrjBx7lqqoIKqarMdB2wmDLroPJcC9otvCz2oQug==",
       "dev": true,
       "dependencies": {
         "@types/debug": "^4.1.8",
         "@types/fs-extra": "^11.0.1",
         "@types/hash-sum": "^1.0.0",
-        "@vuepress/shared": "2.0.0-beta.66",
+        "@vuepress/shared": "2.0.0-beta.67",
         "debug": "^4.3.4",
         "fs-extra": "^11.1.1",
         "globby": "^13.2.2",
         "hash-sum": "^2.0.0",
-        "ora": "^6.3.1",
+        "ora": "^7.0.1",
         "picocolors": "^1.0.0",
         "upath": "^2.0.1"
       }
     },
     "node_modules/@vueuse/core": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.3.0.tgz",
-      "integrity": "sha512-BEM5yxcFKb5btFjTSAFjTu5jmwoW66fyV9uJIP4wUXXU8aR5Hl44gndaaXp7dC5HSObmgbnR2RN+Un1p68Mf5Q==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.4.1.tgz",
+      "integrity": "sha512-DkHIfMIoSIBjMgRRvdIvxsyboRZQmImofLyOHADqiVbQVilP8VVHDhBX2ZqoItOgu7dWa8oXiNnScOdPLhdEXg==",
       "dev": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.17",
-        "@vueuse/metadata": "10.3.0",
-        "@vueuse/shared": "10.3.0",
+        "@vueuse/metadata": "10.4.1",
+        "@vueuse/shared": "10.4.1",
         "vue-demi": ">=0.14.5"
       },
       "funding": {
@@ -1419,9 +1349,9 @@
       }
     },
     "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
-      "integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1445,18 +1375,18 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.3.0.tgz",
-      "integrity": "sha512-Ema3YhNOa4swDsV0V7CEY5JXvK19JI/o1szFO1iWxdFg3vhdFtCtSTP26PCvbUpnUtNHBY2wx5y3WDXND5Pvnw==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.4.1.tgz",
+      "integrity": "sha512-2Sc8X+iVzeuMGHr6O2j4gv/zxvQGGOYETYXEc41h0iZXIRnRbJZGmY/QP8dvzqUelf8vg0p/yEA5VpCEu+WpZg==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.3.0.tgz",
-      "integrity": "sha512-kGqCTEuFPMK4+fNWy6dUOiYmxGcUbtznMwBZLC1PubidF4VZY05B+Oht7Jh7/6x4VOWGpvu3R37WHi81cKpiqg==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.4.1.tgz",
+      "integrity": "sha512-vz5hbAM4qA0lDKmcr2y3pPdU+2EVw/yzfRsBdu+6+USGa4PxqSQRYIUC9/NcT06y+ZgaTsyURw2I9qOFaaXHAg==",
       "dev": true,
       "dependencies": {
         "vue-demi": ">=0.14.5"
@@ -1466,9 +1396,9 @@
       }
     },
     "node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.5.tgz",
-      "integrity": "sha512-o9NUVpl/YlsGJ7t+xuqJKx8EBGf1quRhCiT6D/J0pfwmk9zUwYkC7yrF4SZCe6fETvSM3UNL2edcbYrSyc4QHA==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1934,9 +1864,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001523",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001523.tgz",
-      "integrity": "sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==",
+      "version": "1.0.30001528",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001528.tgz",
+      "integrity": "sha512-0Db4yyjR9QMNlsxh+kKWzQtkyflkG/snYheSzkjmvdEtEXB1+jt7A2HmSEiO6XIJPIbo92lHNGNySvE5pZcs5Q==",
       "dev": true,
       "funding": [
         {
@@ -2029,15 +1959,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -2091,18 +2012,6 @@
         }
       }
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -2115,10 +2024,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.502",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.502.tgz",
-      "integrity": "sha512-xqeGw3Gr6o3uyHy/yKjdnDQHY2RQvXcGC2cfHjccK1IGkH6cX1WQBN8EeC/YpwPhGkBaikDTecJ8+ssxSVRQlw==",
+      "version": "1.4.510",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.510.tgz",
+      "integrity": "sha512-xPfLIPFcN/WLXBpQ/K4UgE98oUBO5Tia6BD4rkSR0wE7ep/PwBVlgvPJQrIBpmJGVAmUzwPKuDbVt9XV6+uC2g==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA==",
       "dev": true
     },
     "node_modules/enhanced-resolve": {
@@ -2289,23 +2210,23 @@
       }
     },
     "node_modules/execa": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^4.3.0",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
         "is-stream": "^3.0.0",
         "merge-stream": "^2.0.0",
         "npm-run-path": "^5.1.0",
         "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
+        "signal-exit": "^4.1.0",
         "strip-final-newline": "^3.0.0"
       },
       "engines": {
-        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+        "node": ">=16.17"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -2336,6 +2257,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/extend-shallow": {
@@ -2402,16 +2335,16 @@
       }
     },
     "node_modules/fraction.js": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.1.tgz",
-      "integrity": "sha512-/KxoyCnPM0GwYI4NN0Iag38Tqt+od3/mLuguepLgCAKPn0ZhC544nssAW0tG2/00zXEYl9W+7hwAIpLHo6Oc7Q==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
+      "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==",
       "dev": true,
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "patreon",
-        "url": "https://www.patreon.com/infusion"
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs-extra": {
@@ -2443,12 +2376,12 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2530,12 +2463,12 @@
       "dev": true
     },
     "node_modules/human-signals": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
       "engines": {
-        "node": ">=14.18.0"
+        "node": ">=16.17.0"
       }
     },
     "node_modules/ieee754": {
@@ -2568,9 +2501,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.3.tgz",
-      "integrity": "sha512-808ZFYMsIRAjLAu5xkKo0TsbY9LBy9H5MazTKIEHerNkg0ymgilGfBPMR/3G7d/ihGmuK2Hw8S1izY2d3kd3wA==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+      "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
       "dev": true
     },
     "node_modules/inherits": {
@@ -3004,23 +2937,23 @@
       }
     },
     "node_modules/ora": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
-      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-7.0.1.tgz",
+      "integrity": "sha512-0TUxTiFJWv+JnjWm4o9yvuskpEJLXTcng8MJuKd+SzAzp2o+OP3HWqNhB4OdJRt1Vsd9/mR0oyaEYlOnL7XIRw==",
       "dev": true,
       "dependencies": {
-        "chalk": "^5.0.0",
+        "chalk": "^5.3.0",
         "cli-cursor": "^4.0.0",
-        "cli-spinners": "^2.6.1",
+        "cli-spinners": "^2.9.0",
         "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^1.1.0",
+        "is-unicode-supported": "^1.3.0",
         "log-symbols": "^5.1.0",
         "stdin-discarder": "^0.1.0",
-        "strip-ansi": "^7.0.1",
-        "wcwidth": "^1.0.1"
+        "string-width": "^6.1.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3237,9 +3170,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.28.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.1.tgz",
-      "integrity": "sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.0.tgz",
+      "integrity": "sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -3500,6 +3433,23 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-6.1.0.tgz",
+      "integrity": "sha512-k01swCJAgQmuADB0YIc+7TuatfNvTBVOoaUWJjTB9R4VJzR5vNWzf5t42ESVZFPS8xTySF7CAdV4t/aaIm3UnQ==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^10.2.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -3563,9 +3513,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.19.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.2.tgz",
-      "integrity": "sha512-qC5+dmecKJA4cpYxRa5aVkKehYsQKc+AHeKl0Oe62aYjBL8ZA33tTljktDHJSaxxMnbI5ZYw+o/S2DxxLu8OfA==",
+      "version": "5.19.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.4.tgz",
+      "integrity": "sha512-6p1DjHeuluwxDXcuT9VR8p64klWJKo1ILiy19s6C9+0Bh2+NWTX6nD9EPppiER4ICkHDVB1RkVpin/YW2nQn/g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -3789,12 +3739,12 @@
       }
     },
     "node_modules/vuepress": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-2.0.0-beta.66.tgz",
-      "integrity": "sha512-BrpORW3QR0/DgtOk6S5EHKG2jn4IURWHI5oLROmc6gpqlZ30T0Ya6pGq9PzG023p9Le5LZVzeuIefEW0srXUYA==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-2.0.0-beta.67.tgz",
+      "integrity": "sha512-931pKDOph20RKMLZAH5YYlMz+nfx9jcOQio1Gxk0pB7DwuSxAVFxPv2dbIUP4E/4uWOkLppRhLYcrOoxEbVYzA==",
       "dev": true,
       "dependencies": {
-        "vuepress-vite": "2.0.0-beta.66"
+        "vuepress-vite": "2.0.0-beta.67"
       },
       "bin": {
         "vuepress": "bin/vuepress.js"
@@ -3804,15 +3754,15 @@
       }
     },
     "node_modules/vuepress-vite": {
-      "version": "2.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/vuepress-vite/-/vuepress-vite-2.0.0-beta.66.tgz",
-      "integrity": "sha512-ezJC+IXDb5j5IrNP91gcvx2/jiSACSOjzK1kNoYSYw/D17j9E6sZ6ddVTFLj6C/vGfhiNT9roP/nvK4TFgsehg==",
+      "version": "2.0.0-beta.67",
+      "resolved": "https://registry.npmjs.org/vuepress-vite/-/vuepress-vite-2.0.0-beta.67.tgz",
+      "integrity": "sha512-oaak2RPKBP0LeaDpDntlsQWLklCBf2vdeceXtPSLV2IzL/wtMHs5DQ/f7zXxCzvku3h/FIstmgoKq/vC0TvHkA==",
       "dev": true,
       "dependencies": {
-        "@vuepress/bundler-vite": "2.0.0-beta.66",
-        "@vuepress/cli": "2.0.0-beta.66",
-        "@vuepress/core": "2.0.0-beta.66",
-        "@vuepress/theme-default": "2.0.0-beta.66",
+        "@vuepress/bundler-vite": "2.0.0-beta.67",
+        "@vuepress/cli": "2.0.0-beta.67",
+        "@vuepress/core": "2.0.0-beta.67",
+        "@vuepress/theme-default": "2.0.0-beta.67",
         "vue": "^3.3.4"
       },
       "bin": {
@@ -3823,7 +3773,7 @@
         "node": ">=16.19.0"
       },
       "peerDependencies": {
-        "@vuepress/client": "2.0.0-beta.66",
+        "@vuepress/client": "2.0.0-beta.67",
         "vue": "^3.3.4"
       }
     },
@@ -3839,15 +3789,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/webpack": {
@@ -3924,9 +3865,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "dev": true,
       "engines": {
         "node": ">= 14"

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,8 +18,8 @@
   },
   "homepage": "https://github.com/nodepa/seedling#readme",
   "devDependencies": {
-    "@vuepress/plugin-docsearch": "^2.0.0-beta.61",
-    "vuepress": "^2.0.0-beta.61"
+    "@vuepress/plugin-docsearch": "^2.0.0-beta.67",
+    "vuepress": "^2.0.0-beta.67"
   },
   "scripts": {
     "build": "vuepress build .",


### PR DESCRIPTION
Because GitHub has updated the default node version and our deployment workflow fails

this commit will:
- update the workflow with the latest version of actions
- set the node version used to latest long term support version

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.