### PR TITLE
fix: Break lines in comprehension exercise text in Safari

### DIFF
--- a/app/src/Comprehension/components/ComprehensionExercise.vue
+++ b/app/src/Comprehension/components/ComprehensionExercise.vue
@@ -461,6 +461,7 @@ function playOptionAudio(option: ComprehensionOption): void {
                     >{{ exercise.comprehensionText[index + 1].word }}
                   </span></span
                 >
+                <wbr />
               </template>
             </ion-card-content>
           </ion-card>


### PR DESCRIPTION
Because Safari & iOS users should have feature and quality parity,

this commit will:
- add a soft line break between `word units` of a comprehension text, where a `word unit` is one or more characters, possibly followed by a punctuation, that constitue a common unit in the presentation to encourage line breaks _after_ punctuation, and also _not_ in the middle of a word of multiple characters (if so defined in the content's word list).

Safari treats CSS line break and word wrap rules in such a way that we need to add a specific tag (`<wbr />`) in the HTML output to handle this use case consistently.

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.

<!-- If this pull request contains a single commit,
there should already be a pull request TITLE and MESSAGE above ^^^.
If they differ significantly from the template below,
please (re-)write the pull request according to:
https://github.com/nodepa/seedling/blob/main/.gitmessage

TITLE format:
feat: Add feature (use imperative mood)
  └── feat, fix, refactor, style, docs, test, content or infra

MESSAGE format:
**Motivation - Why is this change necessary?**
Because

**Impact - How will this commit address the need?**
this commit will:
- add

**Context - Additional information**

**Issues - What issues are involved?**
Resolves #12
Resolves #23

**Certification**
- [ ] I certify that <-- Check the box to certify: [X]
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's
  [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: Name/username <email>
