### PR TITLE
fix: Postpone instruction for comprehension word practice

### DIFF
--- a/app/src/Comprehension/ComprehensionTypes.ts
+++ b/app/src/Comprehension/ComprehensionTypes.ts
@@ -21,6 +21,7 @@ export interface ComprehensionStage {
   instructionText?: string;
   instructionAudio?: ExerciseAudio;
   questionnaire?: boolean;
+  onlyInstructOnRequest?: boolean;
 }
 
 export interface ComprehensionQuestion {

--- a/app/src/Comprehension/components/ComprehensionExercise.vue
+++ b/app/src/Comprehension/components/ComprehensionExercise.vue
@@ -80,12 +80,11 @@ watch(
           (exercise.value.newWordsExercises?.length || 1) - 1
       ) {
         currentExercise.value += 1;
+      } else if (currentStage.value >= STAGE.Review) {
+        ionRouter.navigate({ name: 'Home' }, 'root', 'replace');
       } else {
         exercise.value.stages[currentStage.value].instructionAudio?.cancel();
         currentStage.value += 1;
-      }
-      if (currentStage.value > STAGE.Review) {
-        ionRouter.navigate({ name: 'Home' }, 'root', 'replace');
       }
     }
   },
@@ -94,30 +93,31 @@ watch(currentStage, (currentStage) => {
   switch (currentStage) {
     case STAGE.ReadText:
       store.dispatch('setShowContinueButton', true);
-      togglePlayInstructions();
       break;
     case STAGE.AnswerQuestions:
       currentQuestion.value += 1;
-      togglePlayInstructions();
       break;
     case STAGE.FocusNewWords:
       store.dispatch('setShowContinueButton', true);
-      togglePlayInstructions();
       break;
     case STAGE.PracticeNewWords:
       currentExercise.value += 1;
-      togglePlayInstructions();
       break;
     case STAGE.Review:
       // BUG If multiple choice -> exercise audio plays over instruction
       store.dispatch('setShowContinueButton', true);
-      togglePlayInstructions();
       break;
+  }
+  if (
+    !exercise.value.stages[currentStage].onlyInstructOnRequest &&
+    currentStage != STAGE.PracticeNewWords
+  ) {
+    togglePlayInstructions();
   }
 });
 
 function togglePlayInstructions() {
-  // need to _properly_ suspend other potentially playing audio,
+  // TODO: need to _properly_ suspend other potentially playing audio,
   // while also allow to stop audio by click
   if (currentStage.value === STAGE.AnswerQuestions) {
     if (
@@ -673,8 +673,7 @@ function playOptionAudio(option: ComprehensionOption): void {
           <template
             v-if="
               currentStage === STAGE.PracticeNewWords &&
-              exercise.newWordsExercises &&
-              !exercise.stages[currentStage].instructionAudio?.playing
+              exercise.newWordsExercises
             "
           >
             <MultipleChoiceExercise

--- a/app/src/Lessons/ContentTypes.ts
+++ b/app/src/Lessons/ContentTypes.ts
@@ -119,4 +119,5 @@ export interface ComprehensionStageSpec {
   instructionText?: string;
   instructionAudio?: string;
   questionnaire?: boolean;
+  onlyInstructOnRequest?: boolean;
 }

--- a/app/src/Lessons/ExerciseProvider.ts
+++ b/app/src/Lessons/ExerciseProvider.ts
@@ -924,6 +924,12 @@ export default class ExerciseProvider {
         ) {
           stage.questionnaire = true;
         }
+        if (
+          stageSpec.onlyInstructOnRequest &&
+          [true, 'true'].includes(stageSpec.onlyInstructOnRequest)
+        ) {
+          stage.onlyInstructOnRequest = true;
+        }
         return stage;
       },
     ) as Array<ComprehensionStage>;

--- a/content/Lesson12.json
+++ b/content/Lesson12.json
@@ -190,7 +190,7 @@
             "questionnaire": true
           },
           {
-            "instructionText": "请再次阅读短文，猜猜短文中一些新词语（粉色字体）的意思。然后点击箭头回答问题。",
+            "instructionText": "请再次阅读短文，猜猜短文中一些新词语的意思。然后点击箭头回答问题。",
             "instructionAudio": "audio/短文介绍2.mp3"
           },
           {
@@ -353,7 +353,7 @@
             "questionnaire": true
           },
           {
-            "instructionText": "请再次阅读短文，猜猜短文中一些新词语（粉色字体）的意思。然后点击箭头回答问题。",
+            "instructionText": "请再次阅读短文，猜猜短文中一些新词语的意思。然后点击箭头回答问题。",
             "instructionAudio": "audio/短文介绍2.mp3"
           },
           {

--- a/content/Lesson17.json
+++ b/content/Lesson17.json
@@ -188,7 +188,7 @@
             "questionnaire": true
           },
           {
-            "instructionText": "请再次阅读短文，猜猜短文中一些新词语（粉色字体）的意思。然后点击箭头回答问题。",
+            "instructionText": "请再次阅读短文，猜猜短文中一些新词语的意思。然后点击箭头回答问题。",
             "instructionAudio": "audio/短文介绍2.mp3"
           },
           {

--- a/content/Lesson21.json
+++ b/content/Lesson21.json
@@ -359,7 +359,7 @@
             "questionnaire": true
           },
           {
-            "instructionText": "请再次阅读短文，猜猜短文中一些新词语（粉色字体）的意思。然后点击箭头回答问题。",
+            "instructionText": "请再次阅读短文，猜猜短文中一些新词语的意思。然后点击箭头回答问题。",
             "instructionAudio": "audio/短文介绍2.mp3"
           },
           {


### PR DESCRIPTION
Because the instructions at the start
of the comprehension exercise stage practicing new words
is so similar to the instruction when showing the first related exercise

this commit will:
- introduce a flag that can be set on each stage in the content spec
  that prevents autoplaying instructions when entering that stage
- alway prevent autoplaying instructions for the PracticeNewWords stage
- allow for playing instructions for both non-autoplaying stages
  and for the PracticeNewWords stage upon user request/interaction

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.

<!-- If this pull request contains a single commit,
there should already be a pull request TITLE and MESSAGE above ^^^.
If they differ significantly from the template below,
please (re-)write the pull request according to:
https://github.com/nodepa/seedling/blob/main/.gitmessage

TITLE format:
feat: Add feature (use imperative mood)
  └── feat, fix, refactor, style, docs, test, content or infra

MESSAGE format:
**Motivation - Why is this change necessary?**
Because

**Impact - How will this commit address the need?**
this commit will:
- add

**Context - Additional information**

**Issues - What issues are involved?**
Resolves #12
Resolves #23

**Certification**
- [ ] I certify that <-- Check the box to certify: [X]
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's
  [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: Name/username <email>
