### PR TITLE
fix: Display consecutive icons in review horizontaly

### DIFF
--- a/app/src/views/ReviewSession.vue
+++ b/app/src/views/ReviewSession.vue
@@ -106,13 +106,15 @@ onMounted(() => {
           v-else-if="word.symbol && word.symbol.length > 0"
           style="display: flex; justify-content: center; align-items: center"
         >
-          <ion-icon
-            v-for="(icon, iconIndex) in word.symbol"
-            :key="iconIndex"
-            data-test="review-icon"
-            :icon="Content.getIcon(icon)"
-            style="font-size: 4rem"
-          />
+          <span>
+            <ion-icon
+              v-for="(icon, iconIndex) in word.symbol"
+              :key="iconIndex"
+              data-test="review-icon"
+              :icon="Content.getIcon(icon)"
+              style="font-size: 4rem"
+            />
+          </span>
         </ion-card-header>
         <ion-card-content style="display: flex; flex: 1">
           <ExerciseButton


### PR DESCRIPTION
Because we use icons to represent digits in numbers, and combine multiple icons to represent large numbers, like 65,

this commit will:
- display multiple icons on the same line until the line owerflows, rather than vertically with one icon per line

Resolves #437

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.
