### PR TITLE
docs: Update commit conventions and linting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ https://github.com/nodepa/seedling/blob/main/.gitmessage
 
 TITLE format:
 feat: Add feature (use imperative mood)
-  └── feat, fix, refactor, style, docs, test, content or infra
+  └── chore|content|docs|feat|fix|refactor|revert|style|test
 
 MESSAGE format:
 **Motivation - Why is this change necessary?**
@@ -19,8 +19,7 @@ this commit will:
 **Context - Additional information**
 
 **Issues - What issues are involved?**
-Resolves #12
-Resolves #23
+Resolves #123
 
 **Certification**
 - [ ] I certify that <-- Check the box to certify: [X]
@@ -31,3 +30,4 @@ Resolves #23
   and have the rights to do so.
 
 Signed-off-by: Name/username <email>
+

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,5 +1,5 @@
 feat: Add feature (use imperative mood)
-# └── feat, fix, refactor, style, docs, test, content or infra─────────┤
+# └── chore|content|docs|feat|fix|refactor|revert|style|test ──────────┤
 
 # **Motivation - Why is this change necessary?**
 Because
@@ -11,8 +11,7 @@ this commit will:
 # **Context - Additional information** <!-- Optional section -->
 
 # **Issues - What issues are involved?**
-Resolves #12
-Resolves #23
+Resolves #123
 
 **Certification**
 - [ ] I certify that <!-- Check the box to certify: [X] -->
@@ -39,7 +38,7 @@ Resolves #23
 # - reduce effort needed to comprehend logic
 # - rename varB to audioElement in InstructionsDirective.ts
 #
-# Resolves #12
+# Resolves #123
 #
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
@@ -60,7 +59,7 @@ Resolves #23
 # - clarify differences between the web/PWA experience,
 #   and the native app experience.
 #
-# Closes #12
+# Closes #123
 # Refs #23 (will not auto-close issue)
 #
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
@@ -84,7 +83,7 @@ Resolves #23
 #   - replace hardcoded path with named route for Home screen
 #   - add regression test
 #
-# Fixes #12
+# Fixes #123
 #
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
@@ -110,7 +109,7 @@ Resolves #23
 #   used prior to commit <some hash>
 # - remove unused dependency
 #
-# Fixes #12
+# Fixes #123
 #
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
@@ -137,7 +136,7 @@ Resolves #23
 #   used prior to commit <some hash>
 # - remove unused dependency
 #
-# Fixes #12
+# Fixes #123
 #
 # - [ ] I certify that <!-- Check the box to certify: [X] -->
 # - I have read the [contributing guidelines](
@@ -153,7 +152,7 @@ Resolves #23
 # Commit message guidelines
 # ─────────────────────────────────────────────────────────────────────┐
 # <type>: <summary>
-#    └── feat, fix, refactor, style, docs, test, content or infra──────┤
+#    └── chore|content|docs|feat|fix|refactor|revert|style|test ───────┤
 #
 # <motivation>
 #
@@ -169,13 +168,15 @@ Resolves #23
 # Subject line: <type>: <summary>
 # ─────────────────────────────────────────────────────────────────────┐
 # Start with a <type> from this list (use lowercase):
+#   chore      (maintenance/scripts/dependencies/config/infrastructure)
+#   content    (add/fix/amend files in the content folder)
+#   docs       (add/correct/improve docs/policies/templates/READMEs)
 #   feat       (add new feature/functionality for the user)
 #   fix        (fix bug for the user)
-#   docs       (improve/correct documentation)
-#   style      (amend code formatting/spelling/punctuation)
-#   refactor   (refactor code/improve readability/performance etc)
-#   test       (refactor/add missing test)
-#   infra      (update script/dependency/config/infrastructure)
+#   refactor   (code structure/readability/performance, no fix/feat)
+#   revert     (revert a specific commit)
+#   style      (amend code formatting/spelling/punctuation, no semantic)
+#   test       (add missing tests or correct/refactor existing tests)
 #
 # Proceed to add a <summary> starting with an uppercase letter.
 # Use the imperative mood ("Add feature", not "Added feature").
@@ -201,7 +202,7 @@ Resolves #23
 # environment configurations or additional notes, add it here.
 #
 # Remember to reference relevant GitHub <issues>.
-# Closes #11, fixes #11, resolves #11 and resolves #12
+# Closes #123, fixes #123 and resolves #123
 # are keywords that tell GitHub to automatically close those issues
 # when the pull request is merged into the main branch.
 #

--- a/app/commitlint.config.ts
+++ b/app/commitlint.config.ts
@@ -1,6 +1,6 @@
 // Commit template from .gitmessage:
 // feat: Add feature (use imperative mood)
-// # └── feat, fix, refactor, style, docs, test, content or infra─────────┤
+// # └── chore|content|docs|feat|fix|refactor|revert|style|test ──────────┤
 
 // # **Motivation - Why is this change necessary?**
 // Because
@@ -12,8 +12,7 @@
 // # **Context - Additional information** <!-- Optional section -->
 
 // # **Issues - What issues are involved?**
-// Resolves #12
-// Resolves #23
+// Resolves #123
 
 // **Certification**
 // - [ ] I certify that <!-- Check the box to certify: [X] -->
@@ -37,7 +36,17 @@ export default {
     'type-enum': [
       2,
       'always',
-      ['content', 'docs', 'feat', 'fix', 'infra', 'refactor', 'style', 'test'],
+      [
+        'chore',
+        'content',
+        'docs',
+        'feat',
+        'fix',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+      ],
     ],
     'type-case': [2, 'always', 'lower-case'],
     'scope-enum': [2, 'never'],


### PR DESCRIPTION
Because we have tasks that are better described as chores than infrastructure, as well as missing a commit type for reverting,

this commit will:
- add chore and revert as new commit types,
- remove infra as commit type (replaced by chore)

**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md) and have the rights to do so.

<!-- If this pull request contains a single commit,
there should already be a pull request TITLE and MESSAGE above ^^^.
If they differ significantly from the template below,
please (re-)write the pull request according to:
https://github.com/nodepa/seedling/blob/main/.gitmessage

TITLE format:
feat: Add feature (use imperative mood)
  └── feat, fix, refactor, style, docs, test, content or infra

MESSAGE format:
**Motivation - Why is this change necessary?**
Because

**Impact - How will this commit address the need?**
this commit will:
- add

**Context - Additional information**

**Issues - What issues are involved?**
Resolves #12
Resolves #23

**Certification**
- [ ] I certify that <-- Check the box to certify: [X]
- I have read the [contributing guidelines](
  https://github.com/nodepa/seedling/blob/main/.github/CONTRIBUTING.md)
- I license these contributions to the public under Seedling's
  [LICENSE](https://github.com/nodepa/seedling/blob/main/LICENSE.md)
  and have the rights to do so.

Signed-off-by: Name/username <email>
