### PR TITLE
feat: Redirect to target or /modules after login

### DIFF
--- a/editor/middleware/auth.global.ts
+++ b/editor/middleware/auth.global.ts
@@ -12,10 +12,15 @@ export default defineNuxtRouteMiddleware(async (to) => {
   }
 
   if (to.path === '/login' && isAuthenticated) {
-    return navigateTo('/');
+    return navigateTo('/modules');
+  }
+
+  if ((to.path === '/' || to.path === '') && isAuthenticated) {
+    return navigateTo('/modules');
   }
 
   if (to.path !== '/login' && !isAuthenticated) {
-    return navigateTo('/login');
+    const query = to.path !== '/' ? { redirect: to.fullPath } : {};
+    return navigateTo({ path: '/login', query });
   }
 });

--- a/editor/pages/login.vue
+++ b/editor/pages/login.vue
@@ -32,12 +32,14 @@ import { Hub } from 'aws-amplify/utils';
 
 definePageMeta({ layout: 'login' });
 
+const route = useRoute();
 let unsubscribeHub: (() => void) | undefined;
 
 onMounted(() => {
   unsubscribeHub = Hub.listen('auth', async ({ payload }) => {
     if (payload.event === 'signedIn') {
-      await navigateTo('/');
+      const redirect = route.query.redirect as string | undefined;
+      await navigateTo(redirect || '/modules');
     }
   });
 });


### PR DESCRIPTION
**Certification**
- [X] I certify that <!-- Check the box to certify: [X] -->
- I have read the [contributing guidelines]( https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md).
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.

<!-- If this pull request contains a single commit,
there should already be a pull request TITLE and MESSAGE above ^^^.
If they differ significantly from the template below,
please (re-)write the pull request according to:
https://github.com/nodepa/seedlingo/blob/main/.gitmessage

TITLE format:
feat: Add feature (use imperative mood)
  └── chore|content|docs|feat|fix|refactor|revert|style|test

MESSAGE format:
**Motivation - Why is this change necessary?**
Because

**Impact - How will this commit address the need?**
this commit will:
- add

**Context - Additional information**

**Issues - What issues are involved?**
Resolves #123

**Certification**
- [ ] I certify that <-- Check the box to certify: [X]
- I have read the [contributing guidelines](https://github.com/nodepa/seedlingo/blob/main/.github/CONTRIBUTING.md).
- I license these contributions to the public under Seedlingo's [LICENSE](https://github.com/nodepa/seedlingo/blob/main/LICENSE.md) and have the rights to do so.

Signed-off-by: Name/username <email>

